### PR TITLE
Write feed info to resulting file

### DIFF
--- a/tests/transitfeed/testschedule_write.py
+++ b/tests/transitfeed/testschedule_write.py
@@ -437,6 +437,15 @@ class WriteSampleFeedTestCase(util.TempFileTestCaseBase):
           destination_id=dest_id, contains_id=contains_id)
       schedule.AddFareRuleObject(rule, problems)
 
+    feed_info = transitfeed.FeedInfo()
+    feed_info.feed_version = "0.0.1"
+    feed_info.feed_start_date = "20150101"
+    feed_info.feed_end_date = "20151212"
+    feed_info.feed_publisher_name = "Some Agency"
+    feed_info.feed_publisher_url = "http://www.aurl.com"
+    feed_info.feed_lang = "en"
+    schedule.AddFeedInfoObject(feed_info)
+
     schedule.Validate(problems)
     accumulator.AssertNoMoreExceptions()
     schedule.WriteGoogleTransitFeed(self.tempfilepath)
@@ -514,3 +523,7 @@ class WriteSampleFeedTestCase(util.TempFileTestCaseBase):
 
     self.assertEqual(1, len(read_schedule.GetShapeList()))
     self.assertEqual(shape, read_schedule.GetShape(shape.shape_id))
+
+    self.assertEqual(feed_info, read_schedule.feed_info)
+    self.assertEqual(feed_info.feed_publisher_name, read_schedule.feed_info.feed_publisher_name)
+    self.assertEqual("http://www.aurl.com", read_schedule.feed_info.feed_publisher_url)

--- a/transitfeed/schedule.py
+++ b/transitfeed/schedule.py
@@ -528,6 +528,7 @@ class Schedule(object):
 
     if validate:
       feed_info.Validate(problem_reporter)
+    self.AddTableColumns('feed_info', feed_info._ColumnNames())
     self.feed_info = feed_info
 
   def AddTransferObject(self, transfer, problem_reporter=None):
@@ -622,6 +623,15 @@ class Schedule(object):
       for a in self._agencies.values():
         writer.writerow([util.EncodeUnicode(a[c]) for c in columns])
       self._WriteArchiveString(archive, 'agency.txt', agency_string)
+
+
+    if 'feed_info' in self._table_columns:
+      feed_info_string = StringIO.StringIO()
+      writer = util.CsvUnicodeWriter(feed_info_string)
+      columns = self.GetTableColumns('feed_info')
+      writer.writerow(columns)
+      writer.writerow([util.EncodeUnicode(self.feed_info[c]) for c in columns])
+      self._WriteArchiveString(archive, 'feed_info.txt', feed_info_string)
 
     calendar_dates_string = StringIO.StringIO()
     writer = util.CsvUnicodeWriter(calendar_dates_string)


### PR DESCRIPTION
Feed info object is not being written to the resulting zip file. This PR adds the tests and the solution to this problem.
