### PR TITLE
Update simplejson to json

### DIFF
--- a/schedule_viewer.py
+++ b/schedule_viewer.py
@@ -29,7 +29,7 @@ import mimetypes
 import os.path
 import re
 import signal
-import simplejson
+import json as simplejson
 import socket
 import time
 import transitfeed


### PR DESCRIPTION
When trying to run `schedule_viewer` with the default Python install 2.7.x on Windows, it fails with:

>ImportError: No module named simplejson

This patch uses the standard json package instead, which runs on the default Python install without needing additional components.