### PR TITLE
Adding Google Transit Extension: platform_code

### DIFF
--- a/extensions/googletransit/stop.py
+++ b/extensions/googletransit/stop.py
@@ -26,7 +26,7 @@ class Stop(transitfeed.Stop):
   - Overriding ValidateStopLocationType(), adding location_type 2 (entrance).
   """
 
-  _FIELD_NAMES = transitfeed.Stop._FIELD_NAMES + ['vehicle_type']
+  _FIELD_NAMES = transitfeed.Stop._FIELD_NAMES + ['vehicle_type', 'platform_code']
 
   LOCATION_TYPE_ENTRANCE = 2
 


### PR DESCRIPTION
Adding Google Transit Extension: platform_code

From reference
https://developers.google.com/transit/gtfs/reference/gtfs-extensions#station-platforms

**Field Name:** platform_code	

**Required:** Optional

**Details:**
Indicates the platform identifier for a platform stop. This should be just the platform identifier (eg. "G" or "3"). Words like “platform” or "track" (or the feed’s language-specific equivalent) should not be included. This allows feed consumers to more easily internationalize and localize the platform identifier into other languages.

Currently is showing:

![image](https://cloud.githubusercontent.com/assets/1817333/25975058/c5d83848-3671-11e7-970f-03a5e3aeedd1.png)
