### PR TITLE
Bug fix. Honor stop_sequence given in the input object if present

### DIFF
--- a/transitfeed/trip.py
+++ b/transitfeed/trip.py
@@ -135,12 +135,14 @@ class Trip(GtfsObjectBase):
     row = cursor.fetchone()
     if row[0] is None:
       # This is the first stop_time of the trip
-      stoptime.stop_sequence = 1
+      if stoptime.stop_sequence is None:
+        stoptime.stop_sequence = 1
       if new_secs == None:
         problems.OtherProblem(
             'No time for first StopTime of trip_id "%s"' % (self.trip_id,))
     else:
-      stoptime.stop_sequence = row[0] + 1
+      if stoptime.stop_sequence is None:
+        stoptime.stop_sequence = row[0] + 1
       prev_secs = max(row[1], row[2])
       if new_secs != None and new_secs < prev_secs:
         problems.OtherProblem(


### PR DESCRIPTION
stop_sequence was getting overwritten even though it was given a number while creating.