### PR TITLE
Update setup.py for python3 compatibility.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ from transitfeed import __version__ as VERSION
 try:
   import py2exe
   has_py2exe = True
-except ImportError, e:
+except ImportError:
   # Won't be able to generate win32 exe
   has_py2exe = False
 


### PR DESCRIPTION
The `except` syntax in python3 does not accept multiple exceptions in a single statement. In this case `e` is not being used so it can be dropped.