### PR TITLE
Fix two undefined names: 'returns' and 'frequency'

### DIFF
--- a/transitfeed/frequency.py
+++ b/transitfeed/frequency.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.5
+#!/usr/bin/python
 
 # Copyright (C) 2010 Google Inc.
 #
@@ -77,7 +77,7 @@ class Frequency(GtfsObjectBase):
       return
 
     def Validate(self, problems=None):
-      returns
+      return
 
     def AddToSchedule(self, schedule=None, problems=None):
       if schedule is None:

--- a/transitfeed/trip.py
+++ b/transitfeed/trip.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.5
+#!/usr/bin/python
 
 # Copyright (C) 2007 Google Inc.
 #
@@ -380,7 +380,7 @@ class Trip(GtfsObjectBase):
     warnings.warn("No longer supported. The HeadwayPeriod class was renamed to "
                   "Frequency, and all related functions were renamed "
                   "accordingly.", DeprecationWarning)
-    self.AddFrequencyObject(frequency, problem_reporter)
+    self.AddFrequencyObject(headway_period, problem_reporter)
 
   def AddFrequencyObject(self, frequency, problem_reporter):
     """Add a Frequency object to this trip's list of Frequencies."""


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/google/transitfeed on Python 2.7.13

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./transitfeed/frequency.py:80:7: F821 undefined name 'returns'
      returns
      ^
./transitfeed/trip.py:383:29: F821 undefined name 'frequency'
    self.AddFrequencyObject(frequency, problem_reporter)
                            ^
2       F821 undefined name 'returns'
2
```