### PR TITLE
Fix bottombar's visibility

### DIFF
--- a/gtfsscheduleviewer/files/index.js
+++ b/gtfsscheduleviewer/files/index.js
@@ -605,7 +605,7 @@ function callbackDisplayTripRows(data, responseCode, tripId) {
   html += svgTag("/ttablegraph?height=100&trip=" + encodeURIComponent(tripId), "height='115' width='100%'");
   var bottombarDiv = document.getElementById("bottombar");
   bottombarDiv.style.display = "block";
-  bottombarDiv.style.height = "175px";
+  bottombarDiv.style.height = "198px";
   bottombarDiv.innerHTML = html;
   sizeRouteList();
 }
@@ -670,7 +670,7 @@ function sizeRouteList() {
   var height = windowHeight() - document.getElementById('topbar').offsetHeight - 15 - bottombarHeight;
   document.getElementById('content').style.height = height + 'px';
   if (map) {
-    // Without this displayPolyLine does not use the correct map size
+    // Without this, displayPolyLine does not use the correct map size
     //map.checkResize();
   }
 }


### PR DESCRIPTION
The text element just under the schedule's SVG was partially hidden when
the bottombar's height was set to 175px. I tried to remove the height
property or to set it to auto. This was working great under Chrome, but
Firefox seems to have problem calculating the content element's height...
unless the debug pane was opened (???)

So, for now, fix the height by setting a proper value (198px).

Fix a comment at the same time for readability.

Signed-off-by: Alexandre Demers <alexandre.f.demers@gmail.com>