### PR TITLE
Add transfer extension proposal for from/to_route/trip_id

### DIFF
--- a/extensions/googletransit/setup_extension.py
+++ b/extensions/googletransit/setup_extension.py
@@ -20,6 +20,7 @@ import agency
 import fareattribute
 import route
 import stop
+import transfer
 
 def GetGtfsFactory(factory = None):
   if not factory:
@@ -36,5 +37,8 @@ def GetGtfsFactory(factory = None):
 
   # Stop class extension
   factory.UpdateClass('Stop', stop.Stop)
+
+  # Transfer class extension
+  factory.UpdateClass('Transfer', transfer.Transfer)
 
   return factory

--- a/extensions/googletransit/transfer.py
+++ b/extensions/googletransit/transfer.py
@@ -1,0 +1,60 @@
+#!/usr/bin/python2.5
+
+# Copyright (C) 2011 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import transitfeed
+import transitfeed.util as util
+
+class Transfer(transitfeed.Transfer):
+  """Extension of transitfeed.Transfer:
+  - Adding fields 'from_route_id', to_route_id', 'from_trip_id', 'to_trip_id'  
+    See propposal at 
+    https://developers.google.com/transit/gtfs/reference/gtfs-extensions#TripToTripTransfers
+  """
+
+  _FIELD_NAMES = transitfeed.Transfer._FIELD_NAMES + [ 'from_route_id', 'to_route_id', 'from_trip_id', 'to_trip_id' ]
+  _ID_COLUMNS = transitfeed.Transfer._ID_COLUMNS + [ 'from_route_id', 'to_route_id', 'from_trip_id', 'to_trip_id' ]
+
+  def ValidateFromRouteIdIsValid(self, problems):
+    if not util.IsEmpty(self.from_route_id) and self.from_route_id not in self._schedule.routes.keys():
+      problems.InvalidValue('from_route_id', self.from_route_id)
+      return False
+    return True
+
+  def ValidateToRouteIdIsValid(self, problems):
+    if not util.IsEmpty(self.to_route_id) and self.to_route_id not in self._schedule.routes.keys():
+      problems.InvalidValue('to_route_id', self.to_route_id)
+      return False
+    return True 
+
+  def ValidateFromTripIdIsValid(self, problems):
+    if not util.IsEmpty(self.from_trip_id) and self.from_trip_id not in self._schedule.trips.keys():
+      problems.InvalidValue('from_trip_id', self.from_trip_id)
+      return False
+    return True
+
+  def ValidateToTripIdIsValid(self, problems):
+    if not util.IsEmpty(self.to_trip_id) and self.to_trip_id not in self._schedule.trips.keys():
+      problems.InvalidValue('to_trip_id', self.to_trip_id)
+      return False
+    return True 
+
+  def ValidateAfterAdd(self, problems):
+    result = super(Transfer, self).ValidateAfterAdd(problems)
+    result = self.ValidateFromRouteIdIsValid(problems) and result
+    result = self.ValidateToRouteIdIsValid(problems) and result
+    result = self.ValidateFromTripIdIsValid(problems) and result
+    result = self.ValidateToTripIdIsValid(problems) and result
+    return result

--- a/transitfeed/gtfsfactory.py
+++ b/transitfeed/gtfsfactory.py
@@ -50,8 +50,8 @@ class GtfsFactory(object):
       'Stop': Stop,
       'StopTime': StopTime,
       'Route': Route,
-      'Transfer': Transfer,
       'Trip': Trip,
+      'Transfer': Transfer,
       'Schedule': Schedule,
       'Loader': Loader
     }
@@ -90,12 +90,11 @@ class GtfsFactory(object):
         'routes.txt': { 'required': True, 'loading_order': 20,
                         'classes': ['Route']},
 
-        'transfers.txt': { 'required': False, 'loading_order': 30,
-                           'classes': ['Transfer']},
-
-        'trips.txt': { 'required': True, 'loading_order': 40,
+        'trips.txt': { 'required': True, 'loading_order': 30,
                        'classes': ['Trip']},
 
+        'transfers.txt': { 'required': False, 'loading_order': 40,
+                           'classes': ['Transfer']},
         }
 
   def __getattr__(self, name):


### PR DESCRIPTION
Add support for transfer extension proposal.

This PR adds validity checks for from/to_route/trip_id fields. 
Currently, warnings are only generated for exact duplicate transfer stop/route/trip IDs. No further  specificity checks are performed yet.