### PR TITLE
[python3] Import six, fix urllib issues on python3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 enum34
 pytz
+six

--- a/tests/testfeedvalidator.py
+++ b/tests/testfeedvalidator.py
@@ -26,8 +26,6 @@ import StringIO
 from tests import util
 import transitfeed
 import unittest
-from urllib2 import HTTPError, URLError
-import urllib2
 import zipfile
 
 

--- a/transitfeed/util.py
+++ b/transitfeed/util.py
@@ -26,7 +26,7 @@ import re
 import socket
 import sys
 import time
-import urllib2
+from six.moves import urllib
 
 from . import errors
 from .version import __version__
@@ -190,23 +190,23 @@ def CheckVersion(problems, latest_version=None):
   if not latest_version:
     timeout = 20
     socket.setdefaulttimeout(timeout)
-    request = urllib2.Request(LATEST_RELEASE_VERSION_URL)
+    request = urllib.request.Request(LATEST_RELEASE_VERSION_URL)
 
     try:
-      response = urllib2.urlopen(request)
+      response = urllib.request.urlopen(request)
       content = response.read()
       m = re.search(r'version=(\d+\.\d+\.\d+)', content)
       if m:
         latest_version = m.group(1)
 
-    except urllib2.HTTPError as e:
+    except urllib.error.HTTPError as e:
       description = ('During the new-version check, we failed to reach '
                      'transitfeed server: Reason: %s [%s].' %
                      (e.reason, e.code))
       problems.OtherProblem(
         description=description, type=errors.TYPE_NOTICE)
       return
-    except urllib2.URLError as e:
+    except urllib.error.URLError as e:
       description = ('During the new-version check, we failed to reach '
                      'transitfeed server. Reason: %s.' % e.reason)
       problems.OtherProblem(


### PR DESCRIPTION
Hi all, happy father's day in argentina. There was a country wire power outage over here, I used some of the time to hack in this project to move to python3.

Since the first complains from travis on python3 are about urllib2 not existing on python3, I worked first on that. I imported six because we are all grown ups now and I think adding it should be ok with everyone. At least I hope it is.