### PR TITLE
Fix #Pass the Google Maps API key to the schedule viewer.

### DIFF
--- a/gtfsscheduleviewer/files/index.html
+++ b/gtfsscheduleviewer/files/index.html
@@ -5,7 +5,7 @@
     <title>[agency]</title>
     <link href="file/style.css" rel="stylesheet" type="text/css" />
     <script type="text/javascript"
-            src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBLmKxIq4izZzlXKPeVoAiURcT6z6ynobg&sensor=false">
+            src="https://maps.googleapis.com/maps/api/js?key=[key]">
     </script>
     <script src="/file/markerwithlabel.js"></script>
     <script src="/file/calendarpopup.js" type="text/javascript"></script>


### PR DESCRIPTION
This is a straightforward fix that resolves issue #467 by allowing the GMaps API key to be configured by the Python server.

A related note: the default API key registered to `gtfs.schedule.viewer@gmail.com` seems to still be valid :+1:
