### PR TITLE
WIP: py2/3 compatibility for Load function in transitfeed/loader.py

### DIFF
--- a/tests/testmerge.py
+++ b/tests/testmerge.py
@@ -25,7 +25,7 @@ import os.path
 import re
 from tests import util
 import transitfeed
-from transitfeed.compat import StringIO
+from transitfeed.compat import StringIO, BytesIO
 import unittest
 import zipfile
 
@@ -1479,7 +1479,7 @@ class TestHTMLProblemAccumulator(util.TestCase):
 class MergeInSubprocessTestCase(util.TempDirTestCaseBase):
   def CopyAndModifyTestData(self, zip_path, modify_file, old, new):
     """Return path of zip_path copy with old replaced by new in modify_file."""
-    zipfile_mem = StringIO(open(zip_path, 'rb').read())
+    zipfile_mem = BytesIO(open(zip_path, 'rb').read())
     old_zip = zipfile.ZipFile(zipfile_mem, 'r')
 
     content_dict = self.ConvertZipToDict(old_zip)

--- a/tests/transitfeed/testloader.py
+++ b/tests/transitfeed/testloader.py
@@ -16,13 +16,12 @@
 from __future__ import absolute_import
 
 import re
-from StringIO import StringIO
 import tempfile
 from tests import util
 import transitfeed
+from transitfeed.compat import StringIO, BytesIO
 import zipfile
 import zlib
-
 
 class UnrecognizedColumnRecorder(transitfeed.ProblemReporter):
   """Keeps track of unrecognized column errors."""
@@ -462,7 +461,7 @@ class CsvDictTestCase(util.TestCase):
   def setUp(self):
     self.accumulator = util.RecordingProblemAccumulator(self)
     self.problems = transitfeed.ProblemReporter(self.accumulator)
-    self.zip = zipfile.ZipFile(StringIO(), 'a')
+    self.zip = zipfile.ZipFile(BytesIO(), 'a')
     self.loader = transitfeed.Loader(
         problems=self.problems,
         zip=self.zip)
@@ -733,7 +732,7 @@ class ReadCsvTestCase(util.TestCase):
   def setUp(self):
     self.accumulator = util.RecordingProblemAccumulator(self)
     self.problems = transitfeed.ProblemReporter(self.accumulator)
-    self.zip = zipfile.ZipFile(StringIO(), 'a')
+    self.zip = zipfile.ZipFile(BytesIO(), 'a')
     self.loader = transitfeed.Loader(
         problems=self.problems,
         zip=self.zip)

--- a/tests/transitfeed/testroute.py
+++ b/tests/transitfeed/testroute.py
@@ -17,7 +17,7 @@
 # Unit tests for the route module.
 from __future__ import absolute_import
 
-from StringIO import StringIO
+from transitfeed.compat import BytesIO
 from tests import util
 import transitfeed
 
@@ -59,7 +59,7 @@ class RouteMemoryZipTestCase(util.MemoryZipTestCase):
     route_n = transitfeed.Route(short_name="N", route_type="Bus", route_id="n")
     route_n.n_foo = "bar"
     schedule.AddRouteObject(route_n)
-    saved_schedule_file = StringIO()
+    saved_schedule_file = BytesIO()
     schedule.WriteGoogleTransitFeed(saved_schedule_file)
     self.accumulator.AssertNoMoreExceptions()
 
@@ -79,7 +79,7 @@ class RouteMemoryZipTestCase(util.MemoryZipTestCase):
     load1_problems = util.GetTestFailureProblemReporter(
         self, ("ExpirationDate", "UnrecognizedColumn"))
     schedule = self.MakeLoaderAndLoad(problems=load1_problems)
-    saved_schedule_file = StringIO()
+    saved_schedule_file = BytesIO()
     schedule.WriteGoogleTransitFeed(saved_schedule_file)
 
     self.assertLoadAndCheckExtraValues(saved_schedule_file)

--- a/tests/transitfeed/testtransfer.py
+++ b/tests/transitfeed/testtransfer.py
@@ -15,7 +15,7 @@
 # Unit tests for the transfer module.
 from __future__ import absolute_import
 
-from StringIO import StringIO
+from transitfeed.compat import BytesIO
 import transitfeed
 from tests import util
 
@@ -308,7 +308,7 @@ class TransferObjectTestCase(util.ValidationTestCase):
     schedule.AddTransferObject(transfer)
     transfer.attr2 = "foo2"
 
-    saved_schedule_file = StringIO()
+    saved_schedule_file = BytesIO()
     schedule.WriteGoogleTransitFeed(saved_schedule_file)
     self.accumulator.AssertNoMoreExceptions()
 
@@ -414,7 +414,7 @@ class TransferValidationTestCase(util.MemoryZipTestCase):
     self.assertEquals(3, e.row_num)
     self.accumulator.AssertNoMoreExceptions()
 
-    saved_schedule_file = StringIO()
+    saved_schedule_file = BytesIO()
     schedule.WriteGoogleTransitFeed(saved_schedule_file)
     self.accumulator.AssertNoMoreExceptions()
     load_problems = util.GetTestFailureProblemReporter(

--- a/tests/transitfeed/testtrip.py
+++ b/tests/transitfeed/testtrip.py
@@ -15,7 +15,7 @@
 # Unit tests for the trip module.
 from __future__ import absolute_import
 
-from StringIO import StringIO
+from transitfeed.compat import BytesIO
 from tests import util
 import transitfeed
 
@@ -78,7 +78,7 @@ class TripMemoryZipTestCase(util.MemoryZipTestCase):
     schedule.AddTripObject(trip2)
     trip2.AddStopTime(stop=schedule.GetStop("BULLFROG"), stop_time="09:00:00")
     trip2.AddStopTime(stop=schedule.GetStop("STAGECOACH"), stop_time="09:30:00")
-    saved_schedule_file = StringIO()
+    saved_schedule_file = BytesIO()
     schedule.WriteGoogleTransitFeed(saved_schedule_file)
     self.accumulator.AssertNoMoreExceptions()
 
@@ -100,7 +100,7 @@ class TripMemoryZipTestCase(util.MemoryZipTestCase):
     load1_problems = util.GetTestFailureProblemReporter(
         self, ("ExpirationDate", "UnrecognizedColumn"))
     schedule = self.MakeLoaderAndLoad(problems=load1_problems)
-    saved_schedule_file = StringIO()
+    saved_schedule_file = BytesIO()
     schedule.WriteGoogleTransitFeed(saved_schedule_file)
 
     self.assertLoadAndCheckExtraValues(saved_schedule_file)

--- a/tests/util.py
+++ b/tests/util.py
@@ -27,7 +27,7 @@ import sys
 import tempfile
 import traceback
 import transitfeed
-from transitfeed.compat import StringIO
+from transitfeed.compat import StringIO, BytesIO
 import unittest
 import zipfile
 
@@ -197,7 +197,7 @@ class TempDirTestCaseBase(GetPathTestCase):
 
     Returns:
         The new file's in-memory contents as a file-like object."""
-    zipfile_mem = StringIO()
+    zipfile_mem = BytesIO()
     zip = zipfile.ZipFile(zipfile_mem, 'a')
     for arcname, contents in dict.items():
       zip.writestr(arcname, contents)
@@ -319,7 +319,7 @@ class MemoryZipTestCase(TestCase):
 
   def CreateZip(self):
     """Create an in-memory GTFS zipfile from the contents of the file dict."""
-    self.zipfile = StringIO()
+    self.zipfile = BytesIO()
     self.zip = zipfile.ZipFile(self.zipfile, 'a')
     for (arcname, contents) in self.zip_contents.items():
       self.zip.writestr(arcname, contents)

--- a/transitfeed/compat.py
+++ b/transitfeed/compat.py
@@ -17,3 +17,8 @@ try:  # py2
   from StringIO import StringIO
 except ImportError:
   from io import StringIO
+
+try:  # py2
+  from BytesIO import BytesIO
+except ImportError:
+  from io import BytesIO

--- a/transitfeed/gtfsfactory.py
+++ b/transitfeed/gtfsfactory.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+import sys
+
 from .agency import Agency
 from .fareattribute import FareAttribute
 from .farerule import FareRule
@@ -128,7 +130,12 @@ class GtfsFactory(object):
     """Returns a list of filenames sorted by loading order.
     Only includes files that Loader's standardized loading knows how to load"""
     result = {}
-    for filename, mapping in self._file_mapping.iteritems():
+    if sys.version_info[0] < 3:
+      file_mappings = self._file_mapping.iteritems()
+    else:
+      file_mappings = self._file_mapping.items()
+
+    for filename, mapping in file_mappings:
       loading_order = mapping['loading_order']
       if loading_order is not None:
         result[loading_order] = filename

--- a/transitfeed/gtfsfactory.py
+++ b/transitfeed/gtfsfactory.py
@@ -15,8 +15,6 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-import sys
-
 from .agency import Agency
 from .fareattribute import FareAttribute
 from .farerule import FareRule
@@ -130,12 +128,7 @@ class GtfsFactory(object):
     """Returns a list of filenames sorted by loading order.
     Only includes files that Loader's standardized loading knows how to load"""
     result = {}
-    if sys.version_info[0] < 3:
-      file_mappings = self._file_mapping.iteritems()
-    else:
-      file_mappings = self._file_mapping.items()
-
-    for filename, mapping in file_mappings:
+    for filename, mapping in self._file_mapping.items():
       loading_order = mapping['loading_order']
       if loading_order is not None:
         result[loading_order] = filename

--- a/transitfeed/gtfsobjectbase.py
+++ b/transitfeed/gtfsobjectbase.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+import sys
+
 from .gtfsfactoryuser import GtfsFactoryUser
 
 class GtfsObjectBase(GtfsFactoryUser):
@@ -69,7 +71,12 @@ class GtfsObjectBase(GtfsFactoryUser):
 
   def iteritems(self):
     """Return a iterable for (name, value) pairs of public attributes."""
-    for name, value in self.__dict__.iteritems():
+    if sys.version_info[0] < 3:
+      dict_mapping = self.__dict__.iteritems()
+    else:
+      dict_mapping = self.__dict__.items()
+
+    for name, value in dict_mapping:
       if (not name) or name[0] == "_":
         continue
       yield name, value
@@ -88,7 +95,7 @@ class GtfsObjectBase(GtfsFactoryUser):
     if id(self) == id(other):
       return True
 
-    for k in self.keys().union(other.keys()):
+    for k in list(self.keys().union(other.keys())):
       # use __getitem__ which returns "" for missing columns values
       if self[k] != other[k]:
         return False
@@ -103,7 +110,10 @@ class GtfsObjectBase(GtfsFactoryUser):
   # can't be fixed until the merger is changed to not use a/b_merge_map.
 
   def __repr__(self):
-    return "<%s %s>" % (self.__class__.__name__, sorted(self.iteritems()))
+    if sys.version_info[0] < 3:
+      return "<%s %s>" % (self.__class__.__name__, sorted(self.iteritems()))
+    else:
+      return "<%s %s>" % (self.__class__.__name__, sorted(self.items()))
 
   def keys(self):
     """Return iterable of columns used by this object."""
@@ -115,7 +125,7 @@ class GtfsObjectBase(GtfsFactoryUser):
     return columns
 
   def _ColumnNames(self):
-    return self.keys()
+    return list(self.keys())
 
   def AddToSchedule(self, schedule, problems):
     self._schedule = schedule

--- a/transitfeed/gtfsobjectbase.py
+++ b/transitfeed/gtfsobjectbase.py
@@ -15,8 +15,6 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-import sys
-
 from .gtfsfactoryuser import GtfsFactoryUser
 
 class GtfsObjectBase(GtfsFactoryUser):
@@ -71,12 +69,7 @@ class GtfsObjectBase(GtfsFactoryUser):
 
   def iteritems(self):
     """Return a iterable for (name, value) pairs of public attributes."""
-    if sys.version_info[0] < 3:
-      dict_mapping = self.__dict__.iteritems()
-    else:
-      dict_mapping = self.__dict__.items()
-
-    for name, value in dict_mapping:
+    for name, value in self.__dict__.items():
       if (not name) or name[0] == "_":
         continue
       yield name, value

--- a/transitfeed/gtfsobjectbase.py
+++ b/transitfeed/gtfsobjectbase.py
@@ -110,10 +110,7 @@ class GtfsObjectBase(GtfsFactoryUser):
   # can't be fixed until the merger is changed to not use a/b_merge_map.
 
   def __repr__(self):
-    if sys.version_info[0] < 3:
-      return "<%s %s>" % (self.__class__.__name__, sorted(self.iteritems()))
-    else:
-      return "<%s %s>" % (self.__class__.__name__, sorted(self.items()))
+    return "<%s %s>" % (self.__class__.__name__, sorted(self.iteritems()))
 
   def keys(self):
     """Return iterable of columns used by this object."""

--- a/transitfeed/loader.py
+++ b/transitfeed/loader.py
@@ -421,10 +421,7 @@ class Loader:
         return None
     else:
       try:
-        if sys.version_info[0] < 3:
-          data_file = open(os.path.join(self._path, file_name), 'rb')
-        else:
-          data_file = open(os.path.join(self._path, file_name), 'rb', newline='')
+        data_file = io.open(os.path.join(self._path, file_name), 'rb')
         results = data_file.read()
       except IOError:  # file not found
         self._problems.MissingFile(file_name)

--- a/transitfeed/loader.py
+++ b/transitfeed/loader.py
@@ -159,18 +159,17 @@ class Loader:
     if not contents:
       return
 
+    eol_checker = util.EndOfLineChecker(BytesIO(contents),
+                                   file_name, self._problems)
+    # The csv module doesn't provide a way to skip trailing space, but when I
+    # checked 15/675 feeds had trailing space in a header row and 120 had spaces
+    # after fields. Space after header fields can cause a serious parsing
+    # problem, so warn. Space after body fields can cause a problem time,
+    # integer and id fields; they will be validated at higher levels.
+
     if sys.version_info[0] < 3:
-      eol_checker = util.EndOfLineChecker(StringIO(contents),
-                                     file_name, self._problems)
-      # The csv module doesn't provide a way to skip trailing space, but when I
-      # checked 15/675 feeds had trailing space in a header row and 120 had spaces
-      # after fields. Space after header fields can cause a serious parsing
-      # problem, so warn. Space after body fields can cause a problem time,
-      # integer and id fields; they will be validated at higher levels.
       reader = csv.reader(eol_checker, skipinitialspace=True)
     else:
-      eol_checker = util.EndOfLineChecker(BytesIO(contents),
-                                     file_name, self._problems)
       reader = csv.reader(codecs.iterdecode(eol_checker, 'utf-8', errors='surrogateescape'),  skipinitialspace=True)
 
     raw_header = next(reader)
@@ -303,13 +302,12 @@ class Loader:
     if not contents:
       return
 
+    eol_checker = util.EndOfLineChecker(BytesIO(contents),
+                                   file_name, self._problems)
+
     if sys.version_info[0] < 3:
-      eol_checker = util.EndOfLineChecker(StringIO(contents),
-                                     file_name, self._problems)
       reader = csv.reader(eol_checker)  # Use excel dialect
     else:
-      eol_checker = util.EndOfLineChecker(BytesIO(contents),
-                                     file_name, self._problems)
       reader = csv.reader(codecs.iterdecode(eol_checker,'utf-8', errors='surrogateescape'))  # Use excel dialect
 
     header = next(reader)

--- a/transitfeed/loader.py
+++ b/transitfeed/loader.py
@@ -76,7 +76,12 @@ class Loader:
       assert not self._path
       return True
 
-    if not isinstance(self._path, str) and hasattr(self._path, 'read'):
+    if sys.version_info[0] < 3:
+      is_basestring = isinstance(self._path, basestring)
+    else:
+      is_basestring = isinstance(self._path, str)
+
+    if not is_basestring and hasattr(self._path, 'read'):
       # A file-like object, used for testing with a StringIO file
       self._zip = zipfile.ZipFile(self._path, mode='r')
       return True
@@ -548,7 +553,7 @@ class Loader:
       shape.AddShapePointObjectUnsorted(shapepoint, self._problems)
       self._problems.ClearContext()
 
-    for shape_id, shape in shapes.items():
+    for shape_id, shape in list(shapes.items()):
       self._schedule.AddShapeObject(shape, self._problems)
       del shapes[shape_id]
 

--- a/transitfeed/schedule.py
+++ b/transitfeed/schedule.py
@@ -1108,6 +1108,7 @@ class Schedule(object):
     # (trip_id, first_arrival_secs, last_arrival_secs)
     trip_intervals_by_block_id = defaultdict(lambda: [])
 
+    # TODO: can't sort Trips
     for trip in sorted(self.trips.values()):
       if trip.route_id not in self.routes:
         continue

--- a/transitfeed/schedule.py
+++ b/transitfeed/schedule.py
@@ -48,7 +48,7 @@ from . import gtfsfactoryuser
 from . import problems as problems_module
 from .util import defaultdict
 from . import util
-from .compat import StringIO
+from .compat import BytesIO
 
 class Schedule(object):
   """Represents a Schedule, a collection of stops, routes, trips and
@@ -638,7 +638,7 @@ class Schedule(object):
     archive = zipfile.ZipFile(file, 'w')
 
     if 'agency' in self._table_columns:
-      agency_string = StringIO()
+      agency_string = BytesIO()
       writer = util.CsvUnicodeWriter(agency_string)
       columns = self.GetTableColumns('agency')
       writer.writerow(columns)
@@ -648,14 +648,14 @@ class Schedule(object):
 
 
     if 'feed_info' in self._table_columns:
-      feed_info_string = StringIO()
+      feed_info_string = BytesIO()
       writer = util.CsvUnicodeWriter(feed_info_string)
       columns = self.GetTableColumns('feed_info')
       writer.writerow(columns)
       writer.writerow([util.EncodeUnicode(self.feed_info[c]) for c in columns])
       self._WriteArchiveString(archive, 'feed_info.txt', feed_info_string)
 
-    calendar_dates_string = StringIO()
+    calendar_dates_string = BytesIO()
     writer = util.CsvUnicodeWriter(calendar_dates_string)
     writer.writerow(
         self._gtfs_factory.ServicePeriod._FIELD_NAMES_CALENDAR_DATES)
@@ -670,7 +670,7 @@ class Schedule(object):
       self._WriteArchiveString(archive, 'calendar_dates.txt',
                                calendar_dates_string)
 
-    calendar_string = StringIO()
+    calendar_string = BytesIO()
     writer = util.CsvUnicodeWriter(calendar_string)
     writer.writerow(self._gtfs_factory.ServicePeriod._FIELD_NAMES)
     has_data = False
@@ -683,7 +683,7 @@ class Schedule(object):
       self._WriteArchiveString(archive, 'calendar.txt', calendar_string)
 
     if 'stops' in self._table_columns:
-      stop_string = StringIO()
+      stop_string = BytesIO()
       writer = util.CsvUnicodeWriter(stop_string)
       columns = self.GetTableColumns('stops')
       writer.writerow(columns)
@@ -692,7 +692,7 @@ class Schedule(object):
       self._WriteArchiveString(archive, 'stops.txt', stop_string)
 
     if 'routes' in self._table_columns:
-      route_string = StringIO()
+      route_string = BytesIO()
       writer = util.CsvUnicodeWriter(route_string)
       columns = self.GetTableColumns('routes')
       writer.writerow(columns)
@@ -701,7 +701,7 @@ class Schedule(object):
       self._WriteArchiveString(archive, 'routes.txt', route_string)
 
     if 'trips' in self._table_columns:
-      trips_string = StringIO()
+      trips_string = BytesIO()
       writer = util.CsvUnicodeWriter(trips_string)
       columns = self.GetTableColumns('trips')
       writer.writerow(columns)
@@ -714,7 +714,7 @@ class Schedule(object):
     for trip in self.GetTripList():
       headway_rows += trip.GetFrequencyOutputTuples()
     if headway_rows:
-      headway_string = StringIO()
+      headway_string = BytesIO()
       writer = util.CsvUnicodeWriter(headway_string)
       writer.writerow(self._gtfs_factory.Frequency._FIELD_NAMES)
       writer.writerows(headway_rows)
@@ -722,7 +722,7 @@ class Schedule(object):
 
     # write fares (if applicable)
     if self.GetFareAttributeList():
-      fare_string = StringIO()
+      fare_string = BytesIO()
       writer = util.CsvUnicodeWriter(fare_string)
       writer.writerow(self._gtfs_factory.FareAttribute._FIELD_NAMES)
       writer.writerows(
@@ -735,12 +735,12 @@ class Schedule(object):
       for rule in fare.GetFareRuleList():
         rule_rows.append(rule.GetFieldValuesTuple())
     if rule_rows:
-      rule_string = StringIO()
+      rule_string = BytesIO()
       writer = util.CsvUnicodeWriter(rule_string)
       writer.writerow(self._gtfs_factory.FareRule._FIELD_NAMES)
       writer.writerows(rule_rows)
       self._WriteArchiveString(archive, 'fare_rules.txt', rule_string)
-    stop_times_string = StringIO()
+    stop_times_string = BytesIO()
     writer = util.CsvUnicodeWriter(stop_times_string)
     writer.writerow(self._gtfs_factory.StopTime._FIELD_NAMES)
     for t in self.trips.values():
@@ -755,14 +755,14 @@ class Schedule(object):
         shape_rows.append((shape.shape_id, lat, lon, seq, dist))
         seq += 1
     if shape_rows:
-      shape_string = StringIO()
+      shape_string = BytesIO()
       writer = util.CsvUnicodeWriter(shape_string)
       writer.writerow(self._gtfs_factory.Shape._FIELD_NAMES)
       writer.writerows(shape_rows)
       self._WriteArchiveString(archive, 'shapes.txt', shape_string)
 
     if 'transfers' in self._table_columns:
-      transfer_string = StringIO()
+      transfer_string = BytesIO()
       writer = util.CsvUnicodeWriter(transfer_string)
       columns = self.GetTableColumns('transfers')
       writer.writerow(columns)

--- a/transitfeed/schedule.py
+++ b/transitfeed/schedule.py
@@ -20,6 +20,11 @@ import datetime
 import itertools
 import os
 try:
+  import itertools.izip as zip
+except ImportError:
+  pass
+
+try:
   import sqlite3 as sqlite
   native_sqlite = True
 except ImportError:
@@ -261,7 +266,7 @@ class Schedule(object):
     self.service_periods[service_period.service_id] = service_period
 
   def GetServicePeriodList(self):
-    return self.service_periods.values()
+    return list(self.service_periods.values())
 
   def GetDateRange(self):
     """Returns a tuple of (earliest, latest) dates on which the service periods
@@ -287,8 +292,8 @@ class Schedule(object):
     if not starts or not ends:
       return (None, None, None, None)
 
-    minvalue, minindex = min(itertools.izip(starts, itertools.count()))
-    maxvalue, maxindex = max(itertools.izip(ends, itertools.count()))
+    minvalue, minindex = min(zip(starts, itertools.count()))
+    maxvalue, maxindex = max(zip(ends, itertools.count()))
 
     minreason = (period_list[minindex].HasDateExceptionOn(minvalue) and
                  "earliest service exception date in calendar_dates.txt" or
@@ -1029,8 +1034,7 @@ class Schedule(object):
     # each pair of stations within 2 meters latitude of each other. This avoids
     # doing n^2 comparisons in the average case and doesn't need a spatial
     # index.
-    sorted_stops = filter(lambda s: s.stop_lat and s.stop_lon,
-                          self.GetStopList())
+    sorted_stops = [s for s in self.GetStopList() if s.stop_lat and s.stop_lon]
     sorted_stops.sort(
         key=(lambda x: [x.stop_lat, x.stop_lon, getattr(x, 'stop_id', None)]))
     TWO_METERS_LAT = 0.000018

--- a/transitfeed/trip.py
+++ b/transitfeed/trip.py
@@ -601,7 +601,7 @@ class Trip(GtfsObjectBase):
       # time of the previous. Assumes a stoptimes sorted by sequence
       prev_departure = 0
       prev_stop = None
-      prev_distance = None
+      prev_distance = -1.0
       try:
         route_type = self._schedule.GetRoute(self.route_id).route_type
         max_speed = route_class._ROUTE_TYPES[route_type]['max_speed']

--- a/transitfeed/util.py
+++ b/transitfeed/util.py
@@ -444,9 +444,11 @@ def ValidateYesNoUnknown(value, column_name=None, problems=None):
     return False
 
 def IsEmpty(value):
-  #TODO: WHY is changing this to basestring causing so many tests to fail?
-  # culprit is getattr(gtfs_object, name, None)
-  return value is None or (isinstance(value, basestring) and not value.strip())
+  if sys.version_info[0] < 3:
+    return value is None or (isinstance(value, basestring) and not value.strip())
+  else:
+    return value is None or (isinstance(value, str) and not value.strip())
+
 
 def FindUniqueId(dic):
   """Return a string not used as a key in the dictionary dic"""
@@ -637,7 +639,7 @@ class EndOfLineChecker:
         pass
     else:
       self._problems.InvalidLineEnd(
-        codecs.getencoder('unicode_escape')(m_eol.group())[0],
+        codecs.getencoder('unicode_escape')(m_eol.group().decode('utf-8'))[0],
         (self._name, self._line_number))
     next_line_contents = next_line[0:m_eol.start()]
     for seq, name in INVALID_LINE_SEPARATOR_UTF8.items():

--- a/transitfeed/util.py
+++ b/transitfeed/util.py
@@ -432,7 +432,7 @@ def ColorLuminance(color):
   return (299*r + 587*g + 114*b) / 1000.0
 
 def IsValidYesNoUnknown(value):
-  return value in ['0', '1', '2'];
+  return value in ['0', '1', '2']
 
 def ValidateYesNoUnknown(value, column_name=None, problems=None):
   """Validates a value "0" for uknown, "1" for yes, and "2" for no."""
@@ -444,7 +444,9 @@ def ValidateYesNoUnknown(value, column_name=None, problems=None):
     return False
 
 def IsEmpty(value):
-  return value is None or (isinstance(value, str) and not value.strip())
+  #TODO: WHY is changing this to basestring causing so many tests to fail?
+  # culprit is getattr(gtfs_object, name, None)
+  return value is None or (isinstance(value, basestring) and not value.strip())
 
 def FindUniqueId(dic):
   """Return a string not used as a key in the dictionary dic"""


### PR DESCRIPTION
I realize this is broken, but I'm looking for a little insight/advice on the implementation.
1) Are we shooting for total py2/3 backwards compatibility? I'm assuming yes.
2) Assuming `_GetUtf8Contents()` should return a `bytes` object of utf-8 data.
3) Assuming `EndOfLineChecker` class should take in a `bytes` object of utf-8 data and return `bytes` objects "rows" of utf-8 data.
4) At this point, `csv.reader` in python3 only accepts strings, so I used `codecs.iterdecode('utf-8')` to decode the data before passing it to the reader.

@jarondl any thoughts about better ways to go about implementing this?

Again, realizing this is incomplete, just don't want to get too far down this road before getting feedback