### PR TITLE
Fix crash in transfer validation when a stop has missing coordinates

### DIFF
--- a/transitfeed/transfer.py
+++ b/transitfeed/transfer.py
@@ -15,9 +15,10 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-from .gtfsobjectbase import GtfsObjectBase
 from . import problems as problems_module
 from . import util
+from .gtfsobjectbase import GtfsObjectBase
+
 
 class Transfer(GtfsObjectBase):
   """Represents a transfer in a schedule"""
@@ -154,12 +155,16 @@ class Transfer(GtfsObjectBase):
       return
 
     distance = self.GetTransferDistance()
+    if distance is None:
+      # If the distance cannot be determined because of missing coordinates on a stop, return
+      # The stops.txt validation will report the missing coordinates.
+      return
     # If min_transfer_time + 120s isn't enough for someone walking very fast
     # (2m/s) then issue a warning.
     #
     # Stops that are close together (less than 240m appart) never trigger this
     # warning, regardless of min_transfer_time.
-    FAST_WALKING_SPEED= 2 # 2m/s
+    FAST_WALKING_SPEED = 2  # 2m/s
     if self.min_transfer_time + 120 < distance / FAST_WALKING_SPEED:
       problems.TransferWalkingSpeedTooFast(from_stop_id=self.from_stop_id,
                                            to_stop_id=self.to_stop_id,

--- a/transitfeed/util.py
+++ b/transitfeed/util.py
@@ -230,7 +230,7 @@ def _MaxVersion(versions):
   if len(versions) == 0:
     return None
 
-  version_tuple = lambda x: tuple(int(item) for item in x.split('.')) 
+  version_tuple = lambda x: tuple(int(item) for item in x.split('.'))
   return max(versions, key=version_tuple)
 
 OUTPUT_ENCODING = 'utf-8'
@@ -534,6 +534,8 @@ def ApproximateDistanceBetweenStops(stop1, stop2):
   Earth is a sphere."""
   if (stop1.stop_lat is None or stop1.stop_lon is None or
       stop2.stop_lat is None or stop2.stop_lon is None):
+    print('Cannot determine distance between stops %s and %s due to missing coordinates'
+          % (stop1.stop_id, stop2.stop_id))
     return None
   return ApproximateDistance(stop1.stop_lat, stop1.stop_lon,
                              stop2.stop_lat, stop2.stop_lon)


### PR DESCRIPTION
Currently, when trying to validate a GTFS feed which defines transfers to a station without coordinates, feedvalidator crashes. This fix prevents a division by none to avoid this crash.

After applying this fix, the failing distance calculation is logged to the console, and the stops.txt validation catches the stops without coordinates.

```
FeedValidator extension used: None
Cannot determine distance between stops 9021080080600000 and 9021080080600000 due to missing coordinates
Cannot determine distance between stops 9021080080600000 and 9021080080600000 due to missing coordinates
Cannot determine distance between stops 9022080080600001 and 9021080080600000 due to missing coordinates
Cannot determine distance between stops 9022080080600001 and 9022080010100001 due to missing coordinates
Cannot determine distance between stops 9022074000003001 and 9022080080600001 due to missing coordinates
ERROR: 4 errors and 20353 warnings found

Process finished with exit code 1
```


Original error log:
```
validating sj.zip
FeedValidator extension used: None
Yikes, the program threw an unexpected exception!

Hopefully a complete report has been saved to transitfeedcrash.txt,
though if you are seeing this message we've already disappointed you once
today. Please include the report in a new issue at
https://github.com/google/transitfeed/issues
or an email to the public group transitfeed@googlegroups.com. Sorry!

------------------------------------------------------------
transitfeed version 1.2.16

File "C:/DevTools/transitfeed/feedvalidator.py", line 610, in main
       (feed, options) = ParseCommandLineArguments()
 -->   return RunValidationFromOptions(feed, options)
     
    feed = sj.zip
    options = {'check_duplicate_trips': False, 'manual_entry': True, 'extension': None, 'error_types_ignore_list': None, 'memory_db': False, 'service_gap_interval': 13, 'latest_version': '', 'limit_per_type': 5, 'performance': None, 'output': 'validation-results.html'}

File "C:/DevTools/transitfeed/feedvalidator.py", line 705, in RunValidationFromOptions
       else:
 -->     return RunValidationOutputFromOptions(feed, options)
     
    feed = sj.zip
    options = {'check_duplicate_trips': False, 'manual_entry': True, 'extension': None, 'error_types_ignore_list': None, 'memory_db': False, 'service_gap_interval': 13, 'latest_version': '', 'limit_per_type': 5, 'performance': None, 'output': 'validation-results.html'}

File "C:/DevTools/transitfeed/feedvalidator.py", line 508, in RunValidationOutputFromOptions
       else:
 -->     return RunValidationOutputToFilename(feed, options, options.output)
     
    feed = sj.zip
    options = {'check_duplicate_trips': False, 'manual_entry': True, 'extension': None, 'error_types_ignore_list': None, 'memory_db': False, 'service_gap_interval': 13, 'latest_version': '', 'limit_per_type': 5, 'performance': None, 'output': 'validation-results.html'}

File "C:/DevTools/transitfeed/feedvalidator.py", line 515, in RunValidationOutputToFilename
         output_file = open(output_filename, 'w')
 -->     exit_code = RunValidationOutputToFile(feed, options, output_file)
         output_file.close()
    feed = sj.zip
    output_file = <open file 'validation-results.html', mode 'w' at 0x0000000003FAE540>
    options = {'check_duplicate_trips': False, 'manual_entry': True, 'extension': None, 'error_types_ignore_list': None, 'memory_db': False, 'service_gap_interval': 13, 'latest_version': '', 'limit_per_type': 5, 'performance': None, 'output': 'validation-results.html'}
    output_filename = validation-results.html

File "C:/DevTools/transitfeed/feedvalidator.py", line 533, in RunValidationOutputToFile
       problems = transitfeed.ProblemReporter(accumulator)
 -->   schedule, exit_code = RunValidation(feed, options, problems)
       if isinstance(feed, basestring):
    feed = sj.zip
    accumulator = <__main__.HTMLCountingProblemAccumulator object at 0x000000000401E0F0>
    output_file = <open file 'validation-results.html', mode 'w' at 0x0000000003FAE540>
    problems = <transitfeed.problems.ProblemReporter object at 0x000000000401E0B8>
    options = {'check_duplicate_trips': False, 'manual_entry': True, 'extension': None, 'error_types_ignore_list': None, 'memory_db': False, 'service_gap_interval': 13, 'latest_version': '', 'limit_per_type': 5, 'performance': None, 'output': 'validation-results.html'}

File "C:/DevTools/transitfeed/feedvalidator.py", line 590, in RunValidation
                                    gtfs_factory=gtfs_factory)
 -->   schedule = loader.Load()
       # Start validation: children are already validated by the loader.
    feed = sj.zip
    problems = <transitfeed.problems.ProblemReporter object at 0x000000000401E0B8>
    loader = <transitfeed.loader.Loader instance at 0x000000000402EBC8>
    extension_module = <module 'transitfeed' from 'C:\DevTools\transitfeed\transitfeed\__init__.pyc'>
    options = {'check_duplicate_trips': False, 'manual_entry': True, 'extension': None, 'error_types_ignore_list': None, 'memory_db': False, 'service_gap_interval': 13, 'latest_version': '', 'limit_per_type': 5, 'performance': None, 'output': 'validation-results.html'}
    gtfs_factory = <transitfeed.gtfsfactory.GtfsFactory object at 0x000000000402B1D0>

File "C:\DevTools\transitfeed\transitfeed\loader.py", line 588, in Load
         self._LoadShapes()
 -->     self._LoadFeed()
     
    self = <transitfeed.loader.Loader instance at 0x000000000402EBC8>

File "C:\DevTools\transitfeed\transitfeed\loader.py", line 423, in _LoadFeed
               instance.AddToSchedule(self._schedule, self._problems)
 -->           instance.ValidateAfterAdd(self._problems)
               self._problems.ClearContext()
    row_num = 2088
    d = {'from_trip_id': u'', 'to_stop_id': u'9021080080600000', 'from_stop_id': u'9021080080600000', 'to_trip_id': u'', 'transfer_type': u'2', 'min_transfer_time': u'480'}
    header = ['from_stop_id', 'to_stop_id', 'transfer_type', 'min_transfer_time', 'from_trip_id', 'to_trip_id']
    self = <transitfeed.loader.Loader instance at 0x000000000402EBC8>
    filename = transfers.txt
    instance = <Transfer [('from_stop_id', u'9021080080600000'), ('from_trip_id', u''), ('min_transfer_time', 480), ('to_stop_id', u'9021080080600000'), ('to_trip_id', u''), ('transfer_type', 2)]>
    loading_order = ['agency.txt', 'stops.txt', 'routes.txt', 'trips.txt', 'transfers.txt', 'fare_attributes.txt', 'fare_rules.txt', 'frequencies.txt', 'feed_info.txt']
    object_class = <class 'transitfeed.transfer.Transfer'>
    row = [u'9021080080600000', u'9021080080600000', u'2', u'480', u'', u'']

File "C:\DevTools\transitfeed\transitfeed\transfer.py", line 185, in ValidateAfterAdd
           self.ValidateTransferDistance(problems)
 -->       self.ValidateTransferWalkingTime(problems)
     
    valid_stop_ids = True
    self = <Transfer [('from_stop_id', u'9021080080600000'), ('from_trip_id', u''), ('min_transfer_time', 480), ('to_stop_id', u'9021080080600000'), ('to_trip_id', u''), ('transfer_type', 2)]>
    problems = <transitfeed.problems.ProblemReporter object at 0x000000000401E0B8>

File "C:\DevTools\transitfeed\transitfeed\transfer.py", line 163, in ValidateTransferWalkingTime
         FAST_WALKING_SPEED= 2 # 2m/s
 -->     if self.min_transfer_time + 120 < distance / FAST_WALKING_SPEED:
           problems.TransferWalkingSpeedTooFast(from_stop_id=self.from_stop_id,
    distance = None
    problems = <transitfeed.problems.ProblemReporter object at 0x000000000401E0B8>
    FAST_WALKING_SPEED = 2
    self = <Transfer [('from_stop_id', u'9021080080600000'), ('from_trip_id', u''), ('min_transfer_time', 480), ('to_stop_id', u'9021080080600000'), ('to_trip_id', u''), ('transfer_type', 2)]>

TypeError: unsupported operand type(s) for /: 'NoneType' and 'int'


------------------------------------------------------------

Yikes, the program threw an unexpected exception!

Hopefully a complete report has been saved to transitfeedcrash.txt,
though if you are seeing this message we've already disappointed you once
today. Please include the report in a new issue at
https://github.com/google/transitfeed/issues
or an email to the public group transitfeed@googlegroups.com. Sorry!


Press enter to continue...
```