### PR TITLE
Fix for NameError: global name 'GetStartTime' is not defined in schedule_viewer.py

### DIFF
--- a/transitfeed/trip.py
+++ b/transitfeed/trip.py
@@ -764,4 +764,4 @@ class Trip(GtfsObjectBase):
 
 
 def SortListOfTripByTime(trips):
-  trips.sort(key=GetStartTime)
+  trips.sort(key=Trip.GetStartTime)


### PR DESCRIPTION
Hello!

Trying to use schedule_viewer.py from master returns an error while clicking on a route in the list on the left

```
Exception happened during processing of request from ('127.0.0.1', 57885)
Traceback (most recent call last):
  File "/usr/local/Cellar/python@2/2.7.17_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/SocketServer.py", line 293, in _handle_request_noblock
    self.process_request(request, client_address)
  File "/usr/local/Cellar/python@2/2.7.17_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/SocketServer.py", line 321, in process_request
    self.finish_request(request, client_address)
  File "/usr/local/Cellar/python@2/2.7.17_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/SocketServer.py", line 334, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/local/Cellar/python@2/2.7.17_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/SocketServer.py", line 655, in __init__
    self.handle()
  File "/usr/local/Cellar/python@2/2.7.17_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/BaseHTTPServer.py", line 340, in handle
    self.handle_one_request()
  File "/usr/local/Cellar/python@2/2.7.17_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/BaseHTTPServer.py", line 328, in handle_one_request
    method()
  File "schedule_viewer.py", line 115, in do_GET
    return self.handle_json_wrapper_GET(handler, parsed_params)
  File "schedule_viewer.py", line 262, in handle_json_wrapper_GET
    result = handler(parsed_params)
  File "schedule_viewer.py", line 225, in handle_json_GET_routepatterns
    transitfeed.SortListOfTripByTime(trips)
  File "/Users/olivier/Sites/transitfeed/transitfeed/trip.py", line 768, in SortListOfTripByTime
    trips.sort(key=GetStartTime)
NameError: global name 'GetStartTime' is not defined
```


This seems to have been introduced in commit 6c69936. This fix is simply to scope GetStartTime in Trip instead of global.