### PR TITLE
Allow user to override API key

### DIFF
--- a/gtfsscheduleviewer/files/index.html
+++ b/gtfsscheduleviewer/files/index.html
@@ -5,7 +5,7 @@
     <title>[agency]</title>
     <link href="file/style.css" rel="stylesheet" type="text/css" />
     <script type="text/javascript"
-            src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBLmKxIq4izZzlXKPeVoAiURcT6z6ynobg&sensor=false">
+            src="https://maps.googleapis.com/maps/api/js?key=[key]&sensor=false">
     </script>
     <script src="/file/markerwithlabel.js"></script>
     <script src="/file/calendarpopup.js" type="text/javascript"></script>


### PR DESCRIPTION
Fixed `--key` parameter when running schedule_viewer script.
`python schedule_viewer.py [--key <google_maps_api_key>] --feed_filename <feed_file_or_directory>`