### PR TITLE
Honor the input stop_sequence if present

### DIFF
--- a/transitfeed/trip.py
+++ b/transitfeed/trip.py
@@ -136,12 +136,14 @@ class Trip(GtfsObjectBase):
     row = cursor.fetchone()
     if row[0] is None:
       # This is the first stop_time of the trip
-      stoptime.stop_sequence = 1
+      if stoptime.stop_sequence is None or stoptime.stop_sequence <= 1:
+          stoptime.stop_sequence = 1
       if new_secs == None:
         problems.OtherProblem(
             'No time for first StopTime of trip_id "%s"' % (self.trip_id,))
     else:
-      stoptime.stop_sequence = row[0] + 1
+      if stoptime.stop_sequence is None or stoptime.stop_sequence <= (row[0] + 1):
+          stoptime.stop_sequence = row[0] + 1
       prev_secs = max(row[1], row[2])
       if new_secs != None and new_secs < prev_secs:
         problems.OtherProblem(


### PR DESCRIPTION
If the stoptime object was created with a stop_sequence already, the code was overwriting that.